### PR TITLE
Fix typo in class command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -134,7 +134,7 @@ Format: `class 1 c/CLASS`
 
 * Edits the student at the specified INDEX. The index refers to the index number shown in the displayed student list. The index must be a positive integer 1, 2, 3, …
 * Existing class group will be updated to the input values.
-* You can remove a student's class group by typing c/ without specifying any value after it.
+* You can remove a student's class group by typing `c/` without specifying any value after it.
 
 Examples:
 * ```class 1 c/CS2030S Lab 32``` Edits the class group of the 1st student in the list to be CS2030S Lab 32.

--- a/src/main/java/seedu/address/logic/commands/ClassGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClassGroupCommand.java
@@ -23,9 +23,9 @@ public class ClassGroupCommand extends Command {
             + "by the index number used in the last student listing. "
             + "Existing class will be overwritten by the input.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "c/ [CLASS]\n"
+            + "c/[CLASS]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + "c/ AY2223S1-CS2103T-W12";
+            + "c/AY2223S1-CS2103T-W12";
 
     public static final String MESSAGE_ADD_CLASS_GROUP_SUCCESS = "Added class to Student: %1$s";
     public static final String MESSAGE_DELETE_CLASS_GROUP_SUCCESS = "Removed class from Student: %1$s";


### PR DESCRIPTION
- Fix the typo in the `class` command error message
- Fix error in code formatting in the UG for class command

Closes #144 
Closes #179 