### PR TITLE
Fix Upload Picture

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -151,6 +151,9 @@ Format: `upload-pic INDEX`
 * If no picture exists for the student specified, the selected picture will be assigned to the student.
 * Existing picture will be updated to the input file picture.
 
+<div markdown="span" class="alert alert-warning">:information_source: **Note:**
+You are recommended to select an image of dimensions ratio of about 1:1 otherwise the selected picture may not appear nicely.
+</div>
 
 ### Editing student information : `edit`
 

--- a/src/main/java/seedu/address/logic/commands/UploadPictureCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UploadPictureCommand.java
@@ -55,6 +55,7 @@ public class UploadPictureCommand extends Command {
             throw new CommandException(IMAGE_CONSTRAINTS);
         }
         ImageStorage.uploadImage(studentToEdit, studentPicture);
+        model.updateFilteredStudentList(x -> x.equals(studentToEdit));
         model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_STUDENTS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/storage/ImageStorage.java
+++ b/src/main/java/seedu/address/storage/ImageStorage.java
@@ -93,12 +93,12 @@ public class ImageStorage {
      * @throws CommandException If file cannot be found or unable to read the file.
      */
     public static boolean isJpgFile(File file) throws CommandException {
-        int[] jpgByteArray = new int[] {255, 216, 255, 224};
+        int[] jpgByteArray = new int[] {255, 216};
         requireNonNull(file);
         try {
             FileInputStream inputFile = new FileInputStream(file);
             int checkByte;
-            for (int counter = 0; counter < 4; counter++) {
+            for (int counter = 0; counter < 2; counter++) {
                 checkByte = inputFile.read();
                 if (jpgByteArray[counter] != checkByte) {
                     return false;

--- a/src/main/java/seedu/address/ui/StudentCard.java
+++ b/src/main/java/seedu/address/ui/StudentCard.java
@@ -81,6 +81,7 @@ public class StudentCard extends UiPart<Region> {
         picture.setImage(
                 ImageStorage.getStudentProfileImage(this.student)
         );
+
     }
 
     @Override

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -11,7 +11,9 @@
 
 <?import javafx.scene.image.ImageView?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
-  <ImageView fx:id="picture" fitHeight="99.0" fitWidth="99.0" pickOnBounds="true" preserveRatio="true" />
+  <HBox prefHeight="99" prefWidth="99">
+    <ImageView fx:id="picture"  fitHeight="99.0" fitWidth="99.0" pickOnBounds="true" />
+  </HBox>
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />


### PR DESCRIPTION
Instantly refresh uploaded student picture
Image sizes are fixed to 99 x 99, No longer preserve ratio
Add recommended picture dimensions to UG
closes #146 
closes #136 
closes #148 